### PR TITLE
Mac Compatible Build

### DIFF
--- a/Assets/Scripts/Room/RoomLoader.cs
+++ b/Assets/Scripts/Room/RoomLoader.cs
@@ -57,8 +57,8 @@ public class RoomLoader : MonoBehaviour
 	private static readonly String EtageDirName = "ETAGE";
 	private static readonly String CamSalDirName = "CAMSAL";
 	private static readonly String FolderSeparator = Application.platform == RuntimePlatform.WindowsPlayer ? "\\" : "/";
-	private readonly String EtagePath = GameDataDirName + FolderSeparator + EtageDirName;
-	private readonly String CamSalPath = GameDataDirName + FolderSeparator + CamSalDirName;
+	private static readonly String EtagePath = GameDataDirName + FolderSeparator + EtageDirName;
+	private static readonly String CamSalPath = GameDataDirName + FolderSeparator + CamSalDirName;
 
 	void Start()
 	{

--- a/Assets/Scripts/Room/RoomLoader.cs
+++ b/Assets/Scripts/Room/RoomLoader.cs
@@ -53,14 +53,21 @@ public class RoomLoader : MonoBehaviour
 	public ToggleButton CameraMode;
 	public GameObject Border;
 
+	private static readonly String GameDataDirName = "GAMEDATA";
+	private static readonly String EtageDirName = "ETAGE";
+	private static readonly String CamSalDirName = "CAMSAL";
+	private static readonly String FolderSeparator = Application.platform == RuntimePlatform.WindowsPlayer ? "\\" : "/";
+	private readonly String EtagePath = GameDataDirName + FolderSeparator + EtageDirName;
+	private readonly String CamSalPath = GameDataDirName + FolderSeparator + CamSalDirName;
+
 	void Start()
 	{
-		Directory.CreateDirectory("GAMEDATA");
+		Directory.CreateDirectory(GameDataDirName);
 
 		//check existing ETAGEXX folders
-		floors = Directory.GetDirectories("GAMEDATA")
+		floors = Directory.GetDirectories(GameDataDirName)
 			.Select(x => Path.GetFileName(x))
-			.Where(x => x.StartsWith("ETAGE", StringComparison.InvariantCultureIgnoreCase))
+			.Where(x => x.StartsWith(EtageDirName, StringComparison.InvariantCultureIgnoreCase))
 			.Select(x => int.Parse(x.Substring(5, 2)))
 			.ToList();
 		floor = floors.FirstOrDefault();
@@ -186,7 +193,7 @@ public class RoomLoader : MonoBehaviour
 	void LoadFloor(int floor)
 	{
 		//check folder
-		string folder = string.Format("GAMEDATA\\ETAGE{0:D2}", floor);
+		string folder = string.Format(EtagePath + "{0:D2}", floor);
 		if (!Directory.Exists(folder))
 		{
 			LeftText.text = string.Format("Cannot find folder {0}", folder);
@@ -244,7 +251,7 @@ public class RoomLoader : MonoBehaviour
 			LoadRoom(buffer, 0, room);
 		}
 
-		folder = string.Format("GAMEDATA\\CAMSAL{0:D2}", floor);
+		folder = string.Format(CamSalPath + "{0:D2}", floor);
 		if (Directory.Exists(folder))
 		{
 			foreach (var filePath in Directory.GetFiles(folder).Where(x => new FileInfo(x).Length > 0))
@@ -453,13 +460,13 @@ public class RoomLoader : MonoBehaviour
 	int DetectGame()
 	{
 		//detect game based on number of floors
-		if (Directory.Exists("GAMEDATA\\ETAGE00") && Directory.GetFiles("GAMEDATA\\ETAGE00").Count() > 2)
+		if (Directory.Exists(EtagePath + "00") && Directory.GetFiles(EtagePath + "00").Count() > 2)
 			return 5; //TIME GATE
 		else if (floors.Count >= 15)
 			return 2;
 		else if (floors.Count >= 14)
 			return 3;
-		else if (floors.Count == 1 && Directory.Exists("GAMEDATA\\ETAGE16"))
+		else if (floors.Count == 1 && Directory.Exists(EtagePath + "16"))
 			return 4; //JITD
 		else
 			return 1;


### PR DESCRIPTION
the folder separator "\\" doesn't work for Mac & Linux.
- add a variable `FolderSeparator` base on the current OS
- refactor Directory Name and path into readonly variable

Test:
- check if the room viewer and the model viewer works for time gate & alone in the dark

-----

Also If you want me to build a mac version for you to include in the next release, you can ask me anytime :)